### PR TITLE
DI-1795: Add metric for counting failed dag runs.

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -2,6 +2,7 @@
 import json
 import pickle
 from contextlib import contextmanager
+from datetime import datetime
 
 from airflow.configuration import conf
 from airflow.models import DagModel, DagRun, TaskInstance, TaskFail, XCom
@@ -126,6 +127,46 @@ def get_dag_duration_info():
             )
             .all()
         )
+
+
+def get_dag_failure_info():
+    """Number of times a dag has failed since last success."""
+    with session_scope(Session) as session:
+        last_successful_run = session.query(
+            DagRun.dag_id,
+            func.max(DagRun.execution_date).label("last_success_date")
+        ).filter(
+            DagRun.state == "success"
+        ).group_by(
+            DagRun.dag_id
+        ).subquery()
+
+        number_of_failures = session.query(
+            DagRun.dag_id,
+            func.count(DagRun.dag_id).label("failed_since_last_success")
+        ).join(
+            last_successful_run,
+            DagRun.dag_id == last_successful_run.c.dag_id,
+            isouter=True
+        ).filter(
+            DagRun.execution_date > func.coalesce(
+                last_successful_run.c.last_success_date,
+                datetime.min
+            ),
+            DagRun.state == "failed"
+        ).group_by(
+            DagRun.dag_id
+        ).subquery()
+
+        return session.query(
+            DagRun.dag_id,
+            func.coalesce(number_of_failures.c.failed_since_last_success, 0).label("failures")
+        ).join(
+            number_of_failures,
+            DagRun.dag_id == number_of_failures.c.dag_id,
+            isouter=True
+        ).distinct().all()
+
 
 
 ######################
@@ -417,6 +458,18 @@ class MetricsCollector(object):
             ).total_seconds()
             dag_duration.add_metric([dag.dag_id], dag_duration_value)
         yield dag_duration
+
+        dag_failure_metric = GaugeMetricFamily(
+            "airflow_dag_failures_since_last_success",
+            (
+                "Shows the number of times a dag has failed since it last succeeded,"
+                " or total number of failures if it has never succeeded."
+            ),
+            labels=["dag_id"],
+        )
+        for dag in get_dag_failure_info():
+            dag_failure_metric.add_metric([dag.dag_id], dag.failures)
+        yield dag_failure_metric
 
         # Scheduler Metrics
         dag_scheduler_delay = GaugeMetricFamily(

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(include=['airflow_prometheus_exporter']),
     include_package_data=True,
     url='https://github.com/robinhood/airflow_prometheus_exporter',
-    version='1.0.7.1',
+    version='1.0.7.2',
     entry_points={
         'airflow.plugins': [
             'AirflowPrometheus = airflow_prometheus_exporter.prometheus_exporter:AirflowPrometheusPlugin'


### PR DESCRIPTION
Metric to count failed dag runs since last success.

This metric should display the total number of failures if the dag has
never succeeded and 0 if there are no failed dag runs since the last
success. The query for this metric takes into account active dag_runs.

The generated Postgres query:

```
SELECT DISTINCT dag_run.dag_id, coalesce(anon_1.failed_since_last_success, :coalesce_2) AS coalesce_1
FROM dag_run LEFT OUTER JOIN (SELECT dag_run.dag_id AS dag_id, count(dag_run.dag_id) AS failed_since_last_success
FROM dag_run LEFT OUTER JOIN (SELECT dag_run.dag_id AS dag_id, max(dag_run.execution_date) AS last_success_date
FROM dag_run
WHERE dag_run.state = :state_1 GROUP BY dag_run.dag_id) AS anon_2 ON dag_run.dag_id = anon_2.dag_id
WHERE dag_run.execution_date > coalesce(anon_2.last_success_date, :coalesce_3) AND dag_run.state = :state_2 GROUP BY dag_run.dag_id) AS anon_1 ON dag_run.dag_id = anon_1.dag_id

Params:
{'coalesce_2': 0, 'state_1': 'success', 'coalesce_3': datetime.datetime(1, 1, 1, 0, 0), 'state_2': 'failed'}
```

I have tested this query against the stage k8s airflow db, and it works
as expected.